### PR TITLE
[#7/Feat] 도움 요청 글 조회 및 리워드 획득 기능 구현

### DIFF
--- a/src/main/java/com/help/hyozason_backend/controller/helpboard/HelpBoardController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helpboard/HelpBoardController.java
@@ -1,10 +1,36 @@
 package com.help.hyozason_backend.controller.helpboard;
 
+import com.help.hyozason_backend.dto.helpboard.HelpBoardDTO;
+import com.help.hyozason_backend.service.helpboard.HelpBoardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 //@RequiredArgsConstructor //Lombok으로 스프링에서 DI(의존성 주입)의 방법 중에 생성자 주입을 임의의 코드없이 자동으로 설정해주는 어노테이션
 @RestController //@RestController 어노테이션은 사용된 클래스의 모든 메서드에 자동으로 JSON 변환을 적용
 @RequestMapping("/help")
 public class HelpBoardController {
+    private final HelpBoardService helpBoardService;
+
+    @Autowired
+    public HelpBoardController(HelpBoardService helpBoardService) {
+        this.helpBoardService = helpBoardService;
+    }
+
+    @GetMapping("/read")
+    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(@PageableDefault(size = 10) Pageable pageable) {
+        try {
+            return helpBoardService.getHelpBoards(pageable);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 }

--- a/src/main/java/com/help/hyozason_backend/controller/helpreward/HelpRewardController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helpreward/HelpRewardController.java
@@ -1,10 +1,37 @@
 package com.help.hyozason_backend.controller.helpreward;
 
+import com.help.hyozason_backend.service.helpreward.HelpRewardService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 //@RequiredArgsConstructor //Lombok으로 스프링에서 DI(의존성 주입)의 방법 중에 생성자 주입을 임의의 코드없이 자동으로 설정해주는 어노테이션
 @RestController //@RestController 어노테이션은 사용된 클래스의 모든 메서드에 자동으로 JSON 변환을 적용
 @RequestMapping("/help")
 public class HelpRewardController {
+    private HelpRewardService helpRewardService;
+
+    public HelpRewardController(HelpRewardService helpRewardService) {
+        this.helpRewardService = helpRewardService;
+    }
+
+    @PostMapping("/reward")
+    public ResponseEntity<Object> updateRewards(@RequestBody Map<String, Object> request) {
+        try {
+            int rating = (int) request.get("rating");
+            String userId = (String) request.get("userId");
+            int updatedPoints = helpRewardService.updateRewards(userId, rating);
+
+            return ResponseEntity.ok(updatedPoints);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body("잘못된 입력입니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류입니다.");
+        }
+    }
 }

--- a/src/main/java/com/help/hyozason_backend/dto/helpboard/HelpBoardDTO.java
+++ b/src/main/java/com/help/hyozason_backend/dto/helpboard/HelpBoardDTO.java
@@ -2,13 +2,19 @@ package com.help.hyozason_backend.dto.helpboard;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 
 @Getter
 @Setter
 @NoArgsConstructor // 기본 생성자 자동으로 만들어줌
-
+@AllArgsConstructor
 @ToString //toString 메서드 자동으로 만들어줌
 @Builder
 public class HelpBoardDTO {
-
+    String helpName;
+    String helpCategory;
+    boolean helpAccept;
+    LocalDateTime createdAt;
+    String userId;
 }

--- a/src/main/java/com/help/hyozason_backend/dto/helpreward/HelpRewardDTO.java
+++ b/src/main/java/com/help/hyozason_backend/dto/helpreward/HelpRewardDTO.java
@@ -8,5 +8,11 @@ import lombok.*;
 @ToString //toString 메서드 자동으로 만들어줌
 @Builder
 public class HelpRewardDTO {
+    int rewardScore;
+    String userId;
 
+    public HelpRewardDTO(int rewardScore, String userId) {
+        this.rewardScore = rewardScore;
+        this.userId = userId;
+    }
 }

--- a/src/main/java/com/help/hyozason_backend/entity/helpboard/HelpBoardEntity.java
+++ b/src/main/java/com/help/hyozason_backend/entity/helpboard/HelpBoardEntity.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
 
@@ -19,4 +20,23 @@ public class HelpBoardEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)//는 JPA에서 기본 키를 자동으로 생성할 때 사용하는 방법 중 하나
     @Column(name="helpId")
     long helpId;
+
+    @Column(name = "helpName")
+    String helpName;
+
+    @Column(name = "helpCategory")
+    String helpCategory;
+
+    @Column(name = "helpAccept")
+    Boolean helpAccept;
+
+    @Column(name="createdAt", nullable = false)
+    LocalDateTime createdAt;
+
+    @Column(name = "userId")
+    String userId;
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
 }

--- a/src/main/java/com/help/hyozason_backend/entity/helpreward/HelpRewardEntity.java
+++ b/src/main/java/com/help/hyozason_backend/entity/helpreward/HelpRewardEntity.java
@@ -16,4 +16,10 @@ public class HelpRewardEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)//는 JPA에서 기본 키를 자동으로 생성할 때 사용하는 방법 중 하나
     @Column(name="rewardId")
     long rewardId;
+
+    @Column(name = "rewardScore")
+    int rewardScore;
+
+    @Column(name = "userId")
+    String userId;
 }

--- a/src/main/java/com/help/hyozason_backend/repository/helpboard/HelpBoardRepository.java
+++ b/src/main/java/com/help/hyozason_backend/repository/helpboard/HelpBoardRepository.java
@@ -1,9 +1,12 @@
 package com.help.hyozason_backend.repository.helpboard;
 
 import com.help.hyozason_backend.entity.helpboard.HelpBoardEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HelpBoardRepository extends JpaRepository<HelpBoardEntity,Long> {
+    Page<HelpBoardEntity> findAll(Pageable pageable);
 }

--- a/src/main/java/com/help/hyozason_backend/repository/helpreward/HelpRewardRepository.java
+++ b/src/main/java/com/help/hyozason_backend/repository/helpreward/HelpRewardRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HelpRewardRepository extends JpaRepository<HelpRewardEntity,Long> {
+    HelpRewardEntity findByUserId(String userId);
 }

--- a/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
@@ -1,8 +1,39 @@
 package com.help.hyozason_backend.service.helpboard;
 
+import com.help.hyozason_backend.dto.helpboard.HelpBoardDTO;
+import com.help.hyozason_backend.entity.helpboard.HelpBoardEntity;
 import com.help.hyozason_backend.etc.ResponseService;
+import com.help.hyozason_backend.mapper.helpboard.HelpBoardMapper;
+import com.help.hyozason_backend.repository.helpboard.HelpBoardRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class HelpBoardService extends ResponseService {
+    private final HelpBoardRepository helpBoardRepository;
+    @Autowired
+    public HelpBoardService(HelpBoardRepository helpBoardRepository) {
+        this.helpBoardRepository = helpBoardRepository;
+    }
+
+    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(Pageable pageable) {
+        try {
+            Page<HelpBoardEntity> results = helpBoardRepository.findAll(pageable);
+            List<HelpBoardDTO> helpBoardDTOList = results.getContent().stream()
+                    .map(HelpBoardMapper.INSTANCE::toDTO)
+                    .collect(Collectors.toList());
+            return ResponseEntity.ok(helpBoardDTOList);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
 }

--- a/src/main/java/com/help/hyozason_backend/service/helpreward/HelpRewardService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpreward/HelpRewardService.java
@@ -1,8 +1,51 @@
 package com.help.hyozason_backend.service.helpreward;
 
+import com.help.hyozason_backend.entity.helpreward.HelpRewardEntity;
 import com.help.hyozason_backend.etc.ResponseService;
+import com.help.hyozason_backend.repository.helpreward.HelpRewardRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 public class HelpRewardService extends ResponseService {
+    private HelpRewardRepository helpRewardRepository;
+    private HelpRewardEntity helpRewardEntity;
+    public HelpRewardService(HelpRewardRepository helpRewardRepository) {
+        this.helpRewardRepository = helpRewardRepository;
+        this.helpRewardEntity = new HelpRewardEntity();
+    }
+
+    public int grantRewards(int rating) {
+        switch (rating) {
+            case 1:
+                return 1;
+            case 2:
+                return 2;
+            case 3:
+                return 5;
+            case 4:
+                return 7;
+            case 5:
+                return 10;
+            default:
+                throw new IllegalArgumentException("잘못된 입력입니다.");
+        }
+    }
+
+    public int updateRewards(String userId, int rating) {
+        HelpRewardEntity helpRewardEntity = helpRewardRepository.findByUserId(userId);
+
+        if (helpRewardEntity == null) {
+            helpRewardEntity = new HelpRewardEntity();
+            helpRewardEntity.setUserId(userId);
+            helpRewardEntity.setRewardScore(0);
+        }
+
+        int rewards = grantRewards(rating);
+        int updatedRewards = helpRewardEntity.getRewardScore() + rewards;
+
+        helpRewardEntity.setRewardScore(updatedRewards);
+        helpRewardRepository.save(helpRewardEntity);
+
+        return updatedRewards;
+    }
 }


### PR DESCRIPTION
## 📌 관련 이슈
  closed #7


## ✨ 변경 내용
- 도움 요청 글 조회 및 리워드 힉득 기능 구현

- 도움 요청 글 조회 : 임의로 DB에 값을 저장해 데이터베이스의 helpName, helpCategory, helpAccept, createdAt, userId를 불러오도록 구현했습니다. 글 조회에 대한 기본적인 기능만 구현해 놓아서 로그인 코드가 완료되면 그에 맞게 재수정할 예정입니다. 위치 api 관련하여 값을 어떻게 받아와야 할지 몰라 수요일에 상의 후 그 부분도 추가할 예정..입니다.

- 리워드 획득 : 임의로 별점 1점에 1points, 2점에 2points, 3점에 5points, 4점에 7points, 5점에 10points를 부여하는 것으로 설정해 놓았습니다. 프론트로부터 별점을 받아 와 그를 포인트로 전환하고, 기존의 포인트에 새로 얻은 포인트를 더해 그 값을 DB에 저장하도록 구현했습니다. 별점 당 포인트를 얼마나 부여할 건지, 그리고 디자인 상에는 건너뛰기 버튼이 있던데 그 부분에 대해서는 논의한 적이 없어서 그건 어떻게 동작하도록 할 것인지에 대해 이야기를 해봐야 할 것 같습니다. 관련 부분에 대해서는 도움 요청 글 조회 기능과 함께 수정후 재업로드 하도록 하겠습니다....

- 변경한 클래스 : HelpBoard 및 HelpReward 관련 클래스

- 도움 요청 글 조회 api url : http://localhost:8082/help/read

- 리워드 획득 api url : http://localhost:8082/help/reward
                         body : rating, userId 값


## 📸 스크린샷(선택)
![readTest](https://github.com/HyoZaSon/BackEnd/assets/127376237/ed719c57-92ed-4b64-9406-6530f4ef93c9)
![rewardTest](https://github.com/HyoZaSon/BackEnd/assets/127376237/2ad13ed0-04a6-42c0-a0fc-5893df8c0086)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
