### PR TITLE
[#8/Feat] 문자 전송 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,16 @@
             <artifactId>mapstruct</artifactId>
             <version>1.5.3.Final</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>5.2.1</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.14</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/help/hyozason_backend/controller/helpsms/HelpSmsController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helpsms/HelpSmsController.java
@@ -1,0 +1,31 @@
+package com.help.hyozason_backend.controller.helpsms;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.help.hyozason_backend.dto.helpsms.MessageDTO;
+import com.help.hyozason_backend.dto.helpsms.SmsResponseDTO;
+import com.help.hyozason_backend.service.helpsms.HelpSmsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClientException;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/help")
+public class HelpSmsController {
+    private final HelpSmsService helpSmsService;
+
+    @PostMapping("/send")
+    public String sendSms(@RequestBody MessageDTO messageDto, Model model) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+        SmsResponseDTO response = helpSmsService.sendSms(messageDto);
+        model.addAttribute("response", response);
+        return "result";
+    }
+}

--- a/src/main/java/com/help/hyozason_backend/dto/helplocation/HelpLocationDTO.java
+++ b/src/main/java/com/help/hyozason_backend/dto/helplocation/HelpLocationDTO.java
@@ -1,0 +1,17 @@
+package com.help.hyozason_backend.dto.helplocation;
+
+import java.time.LocalDateTime;
+
+public class HelpLocationDTO {
+    String longitude;
+    String latitude;
+    LocalDateTime createdAt;
+    String userEmail;
+
+    public HelpLocationDTO(String longitude, String latitude, LocalDateTime createdAt, String userEmail) {
+        this.longitude = longitude;
+        this.latitude = latitude;
+        this.createdAt = createdAt;
+        this.userEmail = userEmail;
+    }
+}

--- a/src/main/java/com/help/hyozason_backend/dto/helpregion/HelpRegionDTO.java
+++ b/src/main/java/com/help/hyozason_backend/dto/helpregion/HelpRegionDTO.java
@@ -8,5 +8,11 @@ import lombok.*;
 @ToString //toString 메서드 자동으로 만들어줌
 @Builder
 public class HelpRegionDTO {
+    String regionInfo;
+    String userEmail;
 
+    public HelpRegionDTO(String regionInfo, String userEmail) {
+        this.regionInfo = regionInfo;
+        this.userEmail = userEmail;
+    }
 }

--- a/src/main/java/com/help/hyozason_backend/dto/helpsms/MessageDTO.java
+++ b/src/main/java/com/help/hyozason_backend/dto/helpsms/MessageDTO.java
@@ -1,0 +1,14 @@
+package com.help.hyozason_backend.dto.helpsms;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class MessageDTO {
+    // 발신자 및 내용
+    String to;
+    String content;
+}

--- a/src/main/java/com/help/hyozason_backend/dto/helpsms/SmsRequestDTO.java
+++ b/src/main/java/com/help/hyozason_backend/dto/helpsms/SmsRequestDTO.java
@@ -1,0 +1,18 @@
+package com.help.hyozason_backend.dto.helpsms;
+
+import lombok.*;
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@Builder
+public class SmsRequestDTO {
+    String type;
+    String contentType;
+    String countryCode;
+    String from;
+    String content;
+    List<MessageDTO> messages;
+}

--- a/src/main/java/com/help/hyozason_backend/dto/helpsms/SmsResponseDTO.java
+++ b/src/main/java/com/help/hyozason_backend/dto/helpsms/SmsResponseDTO.java
@@ -1,0 +1,16 @@
+package com.help.hyozason_backend.dto.helpsms;
+
+import lombok.*;
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Setter
+@Builder
+public class SmsResponseDTO {
+    String requestId;
+    LocalDateTime requestTime;
+    String statusCode;
+    String statusName;
+}

--- a/src/main/java/com/help/hyozason_backend/entity/helplocation/HelpLocationEntity.java
+++ b/src/main/java/com/help/hyozason_backend/entity/helplocation/HelpLocationEntity.java
@@ -1,0 +1,33 @@
+package com.help.hyozason_backend.entity.helplocation;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Table(name = "HelpLocation")
+public class HelpLocationEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="locationId")
+    long regionId;
+
+    @Column(name = "longitude")
+    String longitude;
+
+    @Column(name = "latitude")
+    String latitude;
+
+    @Column(name="createdAt", nullable = false)
+    LocalDateTime createdAt;
+
+    @Column(name = "userEmail")
+    String userEmail;
+}

--- a/src/main/java/com/help/hyozason_backend/entity/helpregion/HelpRegionEntity.java
+++ b/src/main/java/com/help/hyozason_backend/entity/helpregion/HelpRegionEntity.java
@@ -16,4 +16,10 @@ public class HelpRegionEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)//는 JPA에서 기본 키를 자동으로 생성할 때 사용하는 방법 중 하나
     @Column(name="regionId")
     long regionId;
+
+    @Column(name = "regionInfo")
+    String regionInfo;
+
+    @Column(name = "userEmail")
+    String userEmail;
 }

--- a/src/main/java/com/help/hyozason_backend/service/helpsms/HelpSmsService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpsms/HelpSmsService.java
@@ -1,0 +1,108 @@
+package com.help.hyozason_backend.service.helpsms;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.help.hyozason_backend.dto.helpsms.MessageDTO;
+import com.help.hyozason_backend.dto.helpsms.SmsRequestDTO;
+import com.help.hyozason_backend.dto.helpsms.SmsResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tomcat.util.codec.binary.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class HelpSmsService {
+
+    @Value("${naver-cloud-sms.accessKey}")
+    private String accessKey;
+
+    @Value("${naver-cloud-sms.secretKey}")
+    private String secretKey;
+
+    @Value("${naver-cloud-sms.serviceId}")
+    private String serviceId;
+
+    @Value("${naver-cloud-sms.senderPhone}")
+    private String phone;
+
+    public String makeSignature(Long time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        String space = " ";
+        String newLine = "\n";
+        String method = "POST";
+        String url = "/sms/v2/services/"+ this.serviceId+"/messages";
+        String timestamp = time.toString();
+        String accessKey = this.accessKey;
+        String secretKey = this.secretKey;
+
+        String message = new StringBuilder()
+                .append(method)
+                .append(space)
+                .append(url)
+                .append(newLine)
+                .append(timestamp)
+                .append(newLine)
+                .append(accessKey)
+                .toString();
+
+        SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(signingKey);
+
+        byte[] rawHmac = mac.doFinal(message.getBytes("UTF-8"));
+        String encodeBase64String = Base64.encodeBase64String(rawHmac);
+
+        return encodeBase64String;
+    }
+
+    public SmsResponseDTO sendSms(MessageDTO messageDTO) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+        Long time = System.currentTimeMillis();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-ncp-apigw-timestamp", time.toString());
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", makeSignature(time));
+
+        List<MessageDTO> messages = new ArrayList<>();
+        messages.add(messageDTO);
+
+        SmsRequestDTO request = SmsRequestDTO.builder()
+                .type("SMS")
+                .contentType("COMM")
+                .countryCode("82")
+                .from(phone)
+                .content(messageDTO.getContent())
+                .messages(messages)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String body = objectMapper.writeValueAsString(request);
+        HttpEntity<String> httpBody = new HttpEntity<>(body, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+        SmsResponseDTO response = restTemplate.postForObject(new URI("https://sens.apigw.ntruss.com/sms/v2/services/"+ serviceId +"/messages"), httpBody, SmsResponseDTO.class);
+
+        return response;
+    }
+}
+
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -14,3 +14,8 @@ spring.thymeleaf.prefix=classpath:/templates/
 
 spring.mvc.formcontent.type-mismatch=error
 spring.mvc.formcontent.charset=UTF-8
+
+naver-cloud-sms.accessKey=accessKey ??
+naver-cloud-sms.secretKey=serviceKey ??
+naver-cloud-sms.serviceId=serviceId ??
+naver-cloud-sms.senderPhone=???? ??


### PR DESCRIPTION
## 📌 관련 이슈
 closed #9


## ✨ 변경 내용
- region 관련 entity, dto 내용 삽입, location 관련 entity, dto 생성 및 내용 삽입

- 현재는 location에 경도, 위도가 저장되어 있어 나중에 region처럼 info로 DB를 변경하게 되면 그에 따라 entity와 dto도 수정하면 될 것 같습니다

- 문자 전송 api를 이용한 문자 전송 기능 구현

- 실제 문자 전송 기능 테스트 할 때는 application.properties의 accessKey, secretKey, serviceId, senderPhone에 실제 값을 기입해야 합니다 지금은 임의로 아무 값이나 넣어놨어요

- 문자 전송 api url : http://localhost:8082/help/send

- 문자 전송 body : to에 발신자 번호, content에 보낼 내용을 입력하면 됩니다


## 📸 스크린샷(선택)
![문자 api 테스트](https://github.com/HyoZaSon/BackEnd/assets/127376237/4c8460eb-79b4-46d9-b365-17b4563ccb8e)

![image](https://github.com/HyoZaSon/BackEnd/assets/127376237/5083e2a0-f594-423c-9dbd-24722ea49464)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

