### PR TITLE
[fix]회원가입 이메일 비교 추가

### DIFF
--- a/src/main/java/com/help/hyozason_backend/service/helpuser/HelpUserService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpuser/HelpUserService.java
@@ -37,17 +37,25 @@ public class HelpUserService  {
     }
 
     public HelpUserEntity register( MemberRequestDto.RegisterMember registerMember) {
-        HelpUserEntity member = new HelpUserEntity(
+        HelpUserEntity member = new HelpUserEntity();
+        if (helpUserDTO.getUserEmail().equals(registerMember.getUserEmail())) {
+            // 이메일이 유효하지 않은 경우 에러 처리
+         member.setRefreshToken( helpUserDTO.getUserToken());
+         member.setUserAge(helpUserDTO.getUserAge());
+         member.setUserEmail( registerMember.getUserEmail());
+         member.setUserGender(helpUserDTO.getUserGender());
+         member.setUserName(helpUserDTO.getUserName());
+         member.setUserPhone( registerMember.getUserPhone());
+         member.setUserRole(registerMember.getUserRole());
 
-                registerMember.getUserEmail(),
-                helpUserDTO.getUserName(),
-                helpUserDTO.getUserAge(),
-                helpUserDTO.getUserGender(),
-                registerMember.getUserPhone(),
-                registerMember.getUserRole(),
-                helpUserDTO.getUserToken());
 
+        }else{
+            BaseException exception = new BaseException(MemberErrorCode.INVALID_MEMBER);
+//            exception.setEmailMessage(registerMember.getUserEmail());
+            throw exception;
+        }
         return member;
+
     }
 
     public MemberResponseDto.TokenInfo registerMember(  MemberRequestDto.RegisterMember registerMember  ) {


### PR DESCRIPTION
## 📌 관련 이슈
#5 

## ✨ 변경 내용
- 회원가입 시  들어온 이메일일 이랑 서버에서 받은 이메일 비교하는 로직 추가
- 이제 이메일 값 다를 경우 에러 메시지 보내질 거에요!! 

## 📸 스크린샷(선택)
- 로그인 시 
<img width="1128" alt="스크린샷 2023-08-08 오후 9 14 20" src="https://github.com/HyoZaSon/BackEnd/assets/101424642/d074b57e-e50e-4480-85fe-b54c56d36cfb">

- 회원가입시 (들어온 이메일이 다를 경우)
<img width="1045" alt="스크린샷 2023-08-08 오후 9 14 38" src="https://github.com/HyoZaSon/BackEnd/assets/101424642/76fe44f4-19ca-47a8-be0b-e0419fa35285">
- 회원가입시 (이메일이 같을 경우)
<img width="1096" alt="스크린샷 2023-08-08 오후 9 14 49" src="https://github.com/HyoZaSon/BackEnd/assets/101424642/a36ab0cd-f75e-42f6-b9f3-badb579c8d8f">

