### PR TITLE
[#31/feat] 도움 요청, 수락 관련 rest api 작성 및 기존 코드 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,11 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.1.2</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/main/java/com/help/hyozason_backend/controller/helpboard/HelpBoardController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helpboard/HelpBoardController.java
@@ -23,7 +23,6 @@ public class HelpBoardController {
     private final HelpBoardService helpBoardService;
     private JwtController jwtController;
 
-
     @Autowired
     public HelpBoardController(HelpBoardService helpBoardService, JwtController jwtController) {
         this.helpBoardService = helpBoardService;

--- a/src/main/java/com/help/hyozason_backend/controller/helpboard/HelpBoardController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helpboard/HelpBoardController.java
@@ -1,7 +1,9 @@
 package com.help.hyozason_backend.controller.helpboard;
 
+import com.help.hyozason_backend.controller.jwt.JwtController;
 import com.help.hyozason_backend.dto.helpboard.HelpBoardDTO;
 import com.help.hyozason_backend.service.helpboard.HelpBoardService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -9,6 +11,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -18,19 +21,34 @@ import java.util.List;
 @RequestMapping("/help")
 public class HelpBoardController {
     private final HelpBoardService helpBoardService;
+    private JwtController jwtController;
+
 
     @Autowired
-    public HelpBoardController(HelpBoardService helpBoardService) {
+    public HelpBoardController(HelpBoardService helpBoardService, JwtController jwtController) {
         this.helpBoardService = helpBoardService;
+        this.jwtController = jwtController;
     }
 
     @GetMapping("/read")
-    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(@PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(
+            @PageableDefault(size = 10) Pageable pageable,
+            @RequestParam(name = "region_2depth_name") String region2DepthName,
+            HttpServletRequest request
+    ) {
         try {
-            return helpBoardService.getHelpBoards(pageable);
+            String userEmail = jwtController.getUserEmail(request);
+            if (userEmail != null && !userEmail.isEmpty()) {
+                // 로그인된 경우
+                return helpBoardService.getHelpBoards(pageable, region2DepthName);
+            } else {
+                // 로그인되지 않은 경우
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
         } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
     }
 }
+

--- a/src/main/java/com/help/hyozason_backend/controller/helprequest/HelpRequestController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helprequest/HelpRequestController.java
@@ -1,6 +1,7 @@
 package com.help.hyozason_backend.controller.helprequest;
 
 
+import com.help.hyozason_backend.controller.jwt.JwtController;
 import com.help.hyozason_backend.dto.helprequest.HelpRequestDTO;
 import com.help.hyozason_backend.entity.helpuser.HelpUserEntity;
 import com.help.hyozason_backend.etc.HelpResponse;
@@ -9,7 +10,10 @@ import com.help.hyozason_backend.etc.ResponseService;
 import com.help.hyozason_backend.repository.helpuser.HelpUserRepository;
 import com.help.hyozason_backend.security.jwt.JwtTokenProvider;
 import com.help.hyozason_backend.service.helprequest.HelpRequestService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -17,8 +21,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,6 +37,8 @@ public class HelpRequestController extends ResponseService {
     private final JwtTokenProvider jwtTokenProvider;
     private final SimpMessageSendingOperations messagingTemplate;
 
+    //private JwtController jwtController;
+
     @Autowired
     public HelpRequestController(HelpRequestService helpRequestService, HelpUserRepository helpUserRepository, JwtTokenProvider jwtTokenProvider,SimpMessageSendingOperations messagingTemplate) {
         this.helpRequestService = helpRequestService;
@@ -41,6 +46,14 @@ public class HelpRequestController extends ResponseService {
         this.jwtTokenProvider = jwtTokenProvider;
         this.messagingTemplate = messagingTemplate;
     }
+
+    /*@Autowired
+    public HelpRequestController(HelpRequestService helpRequestService, HelpUserRepository helpUserRepository, JwtController jwtController) {
+        this.helpRequestService = helpRequestService;
+        this.helpUserRepository = helpUserRepository;
+        this.jwtController = jwtController;
+    }*/
+
 
     @MessageMapping("/hello")
     public void message(Message message){
@@ -102,8 +115,45 @@ public class HelpRequestController extends ResponseService {
             helpRequestService.notifyUserHelpAccepted(helpBoardId,helperUserEntity,helpEmail);
             return setResponse(200,"도움 요청 수락 성공",helpEmail);
         }
-
     }
+
+
+    /*@PostMapping("/write")
+    public ResponseEntity<Long> writeHelpRequest(@RequestBody HelpRequestDTO helpRequestDTO, HttpServletRequest request) throws Exception {
+        try {
+            String userEmail = jwtController.getUserEmail(request);
+            if(userEmail != null && !userEmail.isEmpty()) {
+                Long result = helpRequestService.writeHelpRequest(helpRequestDTO, userEmail);
+                return ResponseEntity.ok(result);
+            }
+            else {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }
+
+    @PostMapping("/accept/{helpBoardId}")
+    public ResponseEntity<String> acceptHelpRequest(@PathVariable Long helpBoardId, @RequestBody HelpUserEntity helperUserEntity, HttpServletRequest request) {
+        try {
+            String userEmail = jwtController.getUserEmail(request);
+            if (userEmail != null && !userEmail.isEmpty()) {
+                String result = helpRequestService.acceptHelpRequest(helpBoardId, helperUserEntity);
+                if (result != null) {
+                    return ResponseEntity.ok("Help request accepted and notifications sent.");
+                } else {
+                    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Help request already accepted or not found.");
+                }
+            } else {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }*/
 
 
 }

--- a/src/main/java/com/help/hyozason_backend/controller/helpreward/HelpRewardController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helpreward/HelpRewardController.java
@@ -1,12 +1,11 @@
 package com.help.hyozason_backend.controller.helpreward;
 
+import com.help.hyozason_backend.controller.jwt.JwtController;
 import com.help.hyozason_backend.service.helpreward.HelpRewardService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
@@ -15,18 +14,39 @@ import java.util.Map;
 @RequestMapping("/help")
 public class HelpRewardController {
     private HelpRewardService helpRewardService;
+    private final JwtController jwtController;
 
-    public HelpRewardController(HelpRewardService helpRewardService) {
+    public HelpRewardController(HelpRewardService helpRewardService, JwtController jwtController) {
         this.helpRewardService = helpRewardService;
+        this.jwtController = jwtController;
     }
 
-    @PostMapping("/reward")
+    /*@PostMapping("/reward")
     public ResponseEntity<Object> updateRewards(@RequestBody Map<String, Object> request) {
         try {
             int rating = (int) request.get("rating");
             String userId = (String) request.get("userId");
             int updatedPoints = helpRewardService.updateRewards(userId, rating);
 
+            return ResponseEntity.ok(updatedPoints);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body("잘못된 입력입니다.");
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("서버 오류입니다.");
+        }
+    }*/
+
+    @GetMapping("/reward")
+    public ResponseEntity<Object> updateRewards(
+            @RequestParam(name = "rating") int rating,
+            HttpServletRequest request
+    ) {
+        try {
+            String userEmail = jwtController.getUserEmail(request);
+            if (userEmail == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+            }
+            int updatedPoints = helpRewardService.updateRewards(userEmail, rating);
             return ResponseEntity.ok(updatedPoints);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body("잘못된 입력입니다.");

--- a/src/main/java/com/help/hyozason_backend/controller/helpsms/HelpSmsController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/helpsms/HelpSmsController.java
@@ -18,11 +18,11 @@ import java.security.NoSuchAlgorithmException;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/help")
+//@RequestMapping("/help")
 public class HelpSmsController {
     private final HelpSmsService helpSmsService;
 
-    @PostMapping("/send")
+    //@PostMapping("/send")
     public String sendSms(@RequestBody MessageDTO messageDto, Model model) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
         SmsResponseDTO response = helpSmsService.sendSms(messageDto);
         model.addAttribute("response", response);

--- a/src/main/java/com/help/hyozason_backend/controller/jwt/JwtController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/jwt/JwtController.java
@@ -1,0 +1,27 @@
+package com.help.hyozason_backend.controller.jwt;
+
+import com.help.hyozason_backend.security.jwt.JwtTokenProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class JwtController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    public JwtController(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public String getUserEmail(HttpServletRequest request) throws Exception {
+        try {
+            return jwtTokenProvider.getMemberIdByToken(jwtTokenProvider.getAccessToken(request));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw e; // 예외를 다시 던져서 상위 메서드로 전달
+        }
+    }
+}
+

--- a/src/main/java/com/help/hyozason_backend/repository/helpboard/HelpBoardRepository.java
+++ b/src/main/java/com/help/hyozason_backend/repository/helpboard/HelpBoardRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface HelpBoardRepository extends JpaRepository<HelpBoardEntity,Long> {
-    Page<HelpBoardEntity> findByHelpLocation_Region2DepthName(String region_2depth_name, Pageable pageable);
+public interface HelpBoardRepository extends JpaRepository<HelpBoardEntity, Long> {
+    Page<HelpBoardEntity> findByLocationInfo(String locationInfo, Pageable pageable);
 }
+

--- a/src/main/java/com/help/hyozason_backend/repository/helpboard/HelpBoardRepository.java
+++ b/src/main/java/com/help/hyozason_backend/repository/helpboard/HelpBoardRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface HelpBoardRepository extends JpaRepository<HelpBoardEntity,Long> {
-    Page<HelpBoardEntity> findAll(Pageable pageable);
+    Page<HelpBoardEntity> findByHelpLocation_Region2DepthName(String region_2depth_name, Pageable pageable);
 }

--- a/src/main/java/com/help/hyozason_backend/repository/helpregion/HelpRegionRepository.java
+++ b/src/main/java/com/help/hyozason_backend/repository/helpregion/HelpRegionRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 @Repository
 public interface HelpRegionRepository extends JpaRepository<HelpRegionEntity,String>{
-    List<HelpRegionEntity> findByRegion2DepthName(String region_2depth_name);
+    List<HelpRegionEntity> findByRegionInfo1(String regionInfo1);
 }
 
 

--- a/src/main/java/com/help/hyozason_backend/repository/helpregion/HelpRegionRepository.java
+++ b/src/main/java/com/help/hyozason_backend/repository/helpregion/HelpRegionRepository.java
@@ -7,8 +7,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface HelpRegionRepository extends JpaRepository<HelpRegionEntity,String>{
+    List<HelpRegionEntity> findByRegion2DepthName(String region_2depth_name);
 }
 
 

--- a/src/main/java/com/help/hyozason_backend/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/help/hyozason_backend/security/jwt/JwtTokenProvider.java
@@ -166,4 +166,22 @@ public class JwtTokenProvider {
             throw new BaseException(AuthErrorCode.EMPTY_JWT);
         }
     }
+
+    public String getAccessToken(HttpServletRequest request) {
+        String token = resolveBearer(request);
+        if (token != null) {
+            try {
+                validateToken(token);
+                return token;
+            } catch (BaseException e) {
+                System.out.println("Error: " + e.getErrorCode());
+                e.printStackTrace();
+                return null;
+            }
+        } else {
+            System.out.println("Error: Invalid or missing token");
+            new Throwable().printStackTrace();
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
@@ -2,9 +2,11 @@ package com.help.hyozason_backend.service.helpboard;
 
 import com.help.hyozason_backend.dto.helpboard.HelpBoardDTO;
 import com.help.hyozason_backend.entity.helpboard.HelpBoardEntity;
+import com.help.hyozason_backend.entity.helpregion.HelpRegionEntity;
 import com.help.hyozason_backend.etc.ResponseService;
 import com.help.hyozason_backend.mapper.helpboard.HelpBoardMapper;
 import com.help.hyozason_backend.repository.helpboard.HelpBoardRepository;
+import com.help.hyozason_backend.repository.helpregion.HelpRegionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,26 +14,41 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 public class HelpBoardService extends ResponseService {
     private final HelpBoardRepository helpBoardRepository;
+    private final HelpRegionRepository helpRegionRepository;
+
     @Autowired
-    public HelpBoardService(HelpBoardRepository helpBoardRepository) {
+    public HelpBoardService(HelpBoardRepository helpBoardRepository, HelpRegionRepository helpRegionRepository) {
         this.helpBoardRepository = helpBoardRepository;
+        this.helpRegionRepository = helpRegionRepository;
     }
 
-    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(Pageable pageable) {
+    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(Pageable pageable, String region_2depth_name) {
         try {
-            Page<HelpBoardEntity> results = helpBoardRepository.findAll(pageable);
-            List<HelpBoardDTO> helpBoardDTOList = results.getContent().stream()
-                    .map(HelpBoardMapper.INSTANCE::toDTO)
-                    .collect(Collectors.toList());
+            List<HelpBoardDTO> helpBoardDTOList = new ArrayList<>();
+
+            // region2DepthName, region3DepthName에 맞는 HelpRegionEntity 조회
+            List<HelpRegionEntity> matchingRegions = helpRegionRepository.findByRegion2DepthName(region_2depth_name);
+
+            // 각 리전 정보별로 HelpBoardEntity 조회하여 DTO로 변환하고 리스트에 추가
+            for (HelpRegionEntity region : matchingRegions) {
+                Page<HelpBoardEntity> results = helpBoardRepository.findByHelpLocation_Region2DepthName(region.getRegionInfo1(), pageable);
+                helpBoardDTOList.addAll(
+                        results.getContent().stream()
+                                .map(HelpBoardMapper.INSTANCE::toDTO)
+                                .collect(Collectors.toList())
+                );
+            }
+
+            // 변환된 DTO 리스트를 ResponseEntity에 담아서 반환
             return ResponseEntity.ok(helpBoardDTOList);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }

--- a/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
@@ -33,12 +33,12 @@ public class HelpBoardService extends ResponseService {
         try {
             List<HelpBoardDTO> helpBoardDTOList = new ArrayList<>();
 
-            // region2DepthName, region3DepthName에 맞는 HelpRegionEntity 조회
-            List<HelpRegionEntity> matchingRegions = helpRegionRepository.findByRegion2DepthName(region_2depth_name);
+            // region_2depth_name에 맞는 HelpRegionEntity 조회
+            List<HelpRegionEntity> matchingRegions = helpRegionRepository.findByRegionInfo1(region_2depth_name);
 
             // 각 리전 정보별로 HelpBoardEntity 조회하여 DTO로 변환하고 리스트에 추가
             for (HelpRegionEntity region : matchingRegions) {
-                Page<HelpBoardEntity> results = helpBoardRepository.findByHelpLocation_Region2DepthName(region.getRegionInfo1(), pageable);
+                Page<HelpBoardEntity> results = helpBoardRepository.findByLocationInfo(region.getRegionInfo1(), pageable);
                 helpBoardDTOList.addAll(
                         results.getContent().stream()
                                 .map(HelpBoardMapper.INSTANCE::toDTO)

--- a/src/main/java/com/help/hyozason_backend/service/helprequest/HelpRequestService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helprequest/HelpRequestService.java
@@ -26,6 +26,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Optional;
 
 @Service
 public class HelpRequestService extends ResponseService {
@@ -165,7 +166,105 @@ public class HelpRequestService extends ResponseService {
         );
 
         helpSmsService.sendSms(messageHelperDTO);
-
-
     }
+
+
+    /*public long writeHelpRequest(HelpRequestDTO helpRequestDTO, String userEmail) {
+        Long helpId =null;
+        //도움 요청 글 작성 및 저장
+        try{
+            //RequestDTO 를 BoardDTO로 매핑
+            HelpBoardDTO helpBoardDTO = HelpBoardDTO.builder()
+                    .helpName(helpRequestDTO.getHelpName())
+                    .helpCategory(helpRequestDTO.getHelpCategory())
+                    .helpAccept(helpRequestDTO.getHelpAccept())
+                    .build();
+            //RequestDTO 를 locationDTO로 매핑
+            HelpLocationDTO locationDTO = HelpLocationDTO.builder()
+                    .locationInfo(helpRequestDTO.getLocationInfo())
+                    *//*.longitude(helpRequestDTO.getLongitude())
+                    .latitude(helpRequestDTO.getLatitude())*//*
+                    .region_2depth_name(helpRequestDTO.getRegion_2depth_name())
+                    //.regionInfo2(helpRequestDTO.getRegionInfo2())
+                    .userEmail(userEmail)
+                    .build();
+
+            //HelpBoardDTO 를 Entity로 매핑
+            HelpBoardEntity helpBoardEntity = HelpBoardMapper.INSTANCE.toEntity(helpBoardDTO);
+            //HelpLocationDTO 를 Entity로 매핑
+            HelpLocationEntity helpLocationEntity = HelpLocationMapper.INSTANCE.toEntity(locationDTO);
+
+            helpBoardRepository.save(helpBoardEntity);
+            helpLocationRepository.save(helpLocationEntity);
+
+            //entity 는 save 메소드 호출 이후에 id 필드에 자동으로 값이 할당된다고 함.
+            helpId =helpBoardEntity.getHelpId();
+
+            //userEmail을 이용하여 usertable 에서 유저 phone 정보 가져온다.
+            HelpUserEntity helpUserEntity = helpUserRepository.findByUserEmail(userEmail);
+
+
+            //여기에 문자 api
+            MessageDTO messageDTO = new MessageDTO();
+            messageDTO.setTo(helpUserEntity.getUserPhone());
+            messageDTO.setContent("도움 요청중입니다. 잠시만 기다려주십시오");
+            helpSmsService.sendSms(messageDTO);
+
+
+            return helpId;
+
+        }catch (Exception e){
+            e.printStackTrace();
+        }
+        return helpId;
+    }
+
+    //사용자 B가 도움을 수락했을때의 비즈니스 로직
+
+    public String acceptHelpRequest(Long helpBoardId, HelpUserEntity helperUserEntity) {
+        Optional<HelpBoardEntity> helpBoardOptional = helpBoardRepository.findById(helpBoardId);
+        if (helpBoardOptional.isPresent()) {
+            HelpBoardEntity helpBoardEntity = helpBoardOptional.get();
+            if (!"Accept".equals(helpBoardEntity.getHelpAccept())) {
+                helpBoardEntity.setHelpAccept("Accept");
+                helpBoardRepository.save(helpBoardEntity);
+
+                try {
+                    notifyUserHelpAccepted(helperUserEntity, helpBoardEntity.getUserEmail());
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+                return helpBoardEntity.getUserEmail();
+            } else {
+                // 이미 다른 사람이 수락한 요청인 경우
+                helpBoardRepository.deleteById(helpBoardId);
+            }
+        }
+        return null;
+    }
+
+
+    public void notifyUserHelpAccepted(HelpUserEntity helperUserEntity, String helpEmail) throws UnsupportedEncodingException, URISyntaxException, NoSuchAlgorithmException, InvalidKeyException, JsonProcessingException {
+
+        HelpUserEntity helpUserEntity = helpUserRepository.findByUserEmail(helpEmail);
+
+        //도움 요청
+        MessageDTO messageHelpDTO = new MessageDTO();
+        messageHelpDTO.setTo(helpUserEntity.getUserPhone());
+        messageHelpDTO.setContent("도움 요청이 수락되었습니다.\n"+
+                "도움을 수락한 사용자의 연락처 :"+helperUserEntity.getUserPhone()
+                +"\n도움을 수락한 사용자의 이름 :"+helperUserEntity.getUserName()
+        );
+        helpSmsService.sendSms(messageHelpDTO);
+
+        //도움 수락
+        MessageDTO messageHelperDTO = new MessageDTO();
+        messageHelperDTO.setTo(helperUserEntity.getUserPhone());
+        messageHelperDTO.setContent("도움 요청이 수락되었습니다.\n"+
+                "도움을 요청한 사용자의 연락처 :"+helpUserEntity.getUserPhone()
+                +"\n도움을 요청한 사용자의 이름 :"+helpUserEntity.getUserName()
+        );
+
+        helpSmsService.sendSms(messageHelperDTO);
+    }*/
 }

--- a/src/main/java/com/help/hyozason_backend/service/helpreward/HelpRewardService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpreward/HelpRewardService.java
@@ -16,16 +16,18 @@ public class HelpRewardService extends ResponseService {
 
     public int grantRewards(int rating) {
         switch (rating) {
+            case 0:
+                return 0;
             case 1:
-                return 1;
-            case 2:
-                return 2;
-            case 3:
-                return 5;
-            case 4:
-                return 7;
-            case 5:
                 return 10;
+            case 2:
+                return 20;
+            case 3:
+                return 30;
+            case 4:
+                return 40;
+            case 5:
+                return 50;
             default:
                 throw new IllegalArgumentException("잘못된 입력입니다.");
         }


### PR DESCRIPTION
## 📌 관련 이슈
  closed #31


## ✨ 변경 내용
- 빌드 관련 오류가 있어 다시 업로드했습니다

- 도움 요청(글 작성), 도움 수락(helpAccept 상태 변경, 수락시 메시지 전송) 관련 api 작성

- 현재 코드 동작을 확인할 수가 없어서 로그인 관련 기능 수정 이후 다시 코드 돌려보고 에러 수정할 예정입니다...

- 해송님 웹소켓 테스트 계속 하시는 것 같아서 현재 제가 쓴 코드는 다 주석 처리 해놨습니다 그냥 그대로 돌려보셔도 될 것 같아요

- 기존 코드(글 조회, 리워드 획득) 부분에 로그인 확인 기능 추가 -> 동작 확인 필요

- 로그인 확인 기능 추가를 위해 JwtController JwtTokenProvider 클래스에 getAccessToken 메서드 추가 (token을 통해 userEmail을 받아오고 userEmail의 값이 비어있으면 로그인 되어 있지 않은 것으로 처리)

- 도움 요청 글을 같은 구(region_2depth_name)일 때만 조회할 수 있도록 수정

- 리워드 획득의 포인트 값 변경 (별점 0점 추가)


## 📸 스크린샷(선택)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

