### PR TITLE
[#35/Fix] 글 조회 기능 수정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,8 +127,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
-
-
     </dependencies>
 
     <build>

--- a/src/main/java/com/help/hyozason_backend/controller/jwt/JwtController.java
+++ b/src/main/java/com/help/hyozason_backend/controller/jwt/JwtController.java
@@ -15,13 +15,23 @@ public class JwtController {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
-    public String getUserEmail(HttpServletRequest request) throws Exception {
+    /*public String getUserEmail(HttpServletRequest request) throws Exception {
         try {
             return jwtTokenProvider.getMemberIdByToken(jwtTokenProvider.getAccessToken(request));
         } catch (Exception e) {
             e.printStackTrace();
             throw e; // 예외를 다시 던져서 상위 메서드로 전달
         }
+    }*/
+
+    public String getUserEmail(HttpServletRequest request) {
+        try {
+            return jwtTokenProvider.getMemberIdByToken(jwtTokenProvider.getAccessToken(request));
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Failed to retrieve user email from JWT token.", e);
+        }
     }
+
 }
 

--- a/src/main/java/com/help/hyozason_backend/repository/helpregion/HelpRegionRepository.java
+++ b/src/main/java/com/help/hyozason_backend/repository/helpregion/HelpRegionRepository.java
@@ -12,8 +12,6 @@ import java.util.List;
 
 @Repository
 public interface HelpRegionRepository extends JpaRepository<HelpRegionEntity,String>{
-
-
     HelpRegionEntity findByUserEmail(String userEmail);
 
     List<HelpRegionEntity> findByRegionInfo1(String regionInfo1);

--- a/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helpboard/HelpBoardService.java
@@ -1,5 +1,6 @@
 package com.help.hyozason_backend.service.helpboard;
 
+import com.help.hyozason_backend.controller.jwt.JwtController;
 import com.help.hyozason_backend.dto.helpboard.HelpBoardDTO;
 import com.help.hyozason_backend.entity.helpboard.HelpBoardEntity;
 import com.help.hyozason_backend.entity.helpregion.HelpRegionEntity;
@@ -15,21 +16,20 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 public class HelpBoardService extends ResponseService {
     private final HelpBoardRepository helpBoardRepository;
-    private final HelpRegionRepository helpRegionRepository;
 
     @Autowired
-    public HelpBoardService(HelpBoardRepository helpBoardRepository, HelpRegionRepository helpRegionRepository) {
+    public HelpBoardService(HelpBoardRepository helpBoardRepository) {
         this.helpBoardRepository = helpBoardRepository;
-        this.helpRegionRepository = helpRegionRepository;
     }
 
-    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(Pageable pageable, String region_2depth_name) {
+    /*public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(Pageable pageable, String region_2depth_name) {
         try {
             List<HelpBoardDTO> helpBoardDTOList = new ArrayList<>();
 
@@ -47,6 +47,31 @@ public class HelpBoardService extends ResponseService {
             }
 
             // 변환된 DTO 리스트를 ResponseEntity에 담아서 반환
+            return ResponseEntity.ok(helpBoardDTOList);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
+    }*/
+
+    public ResponseEntity<List<HelpBoardDTO>> getHelpBoards(Pageable pageable, String userEmail) {
+        try {
+            List<HelpBoardDTO> helpBoardDTOList = new ArrayList<>();
+
+            if (userEmail == null) {
+                // userEmail이 null일 경우 처리
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Collections.emptyList());
+            }
+
+            // 사용자의 지역에 해당하는 글만 조회
+            Page<HelpBoardEntity> results = helpBoardRepository.findByLocationInfo(userEmail, pageable);
+
+            helpBoardDTOList.addAll(
+                    results.getContent().stream()
+                            .map(HelpBoardMapper.INSTANCE::toDTO)
+                            .collect(Collectors.toList())
+            );
+
             return ResponseEntity.ok(helpBoardDTOList);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/help/hyozason_backend/service/helprequest/HelpRequestService.java
+++ b/src/main/java/com/help/hyozason_backend/service/helprequest/HelpRequestService.java
@@ -182,8 +182,8 @@ public class HelpRequestService extends ResponseService {
             //RequestDTO 를 locationDTO로 매핑
             HelpLocationDTO locationDTO = HelpLocationDTO.builder()
                     .locationInfo(helpRequestDTO.getLocationInfo())
-                    *//*.longitude(helpRequestDTO.getLongitude())
-                    .latitude(helpRequestDTO.getLatitude())*//*
+                    //.longitude(helpRequestDTO.getLongitude())
+                    //.latitude(helpRequestDTO.getLatitude())*
                     .region_2depth_name(helpRequestDTO.getRegion_2depth_name())
                     //.regionInfo2(helpRequestDTO.getRegionInfo2())
                     .userEmail(userEmail)
@@ -251,18 +251,18 @@ public class HelpRequestService extends ResponseService {
         //도움 요청
         MessageDTO messageHelpDTO = new MessageDTO();
         messageHelpDTO.setTo(helpUserEntity.getUserPhone());
-        messageHelpDTO.setContent("도움 요청이 수락되었습니다.\n"+
-                "도움을 수락한 사용자의 연락처 :"+helperUserEntity.getUserPhone()
-                +"\n도움을 수락한 사용자의 이름 :"+helperUserEntity.getUserName()
+        messageHelpDTO.setContent("도움 요청이 수락되었습니다.\n" +
+                "도움을 수락한 사용자의 연락처 :" + helperUserEntity.getUserPhone()
+                + "\n도움을 수락한 사용자의 이름 :" + helperUserEntity.getUserName()
         );
         helpSmsService.sendSms(messageHelpDTO);
 
         //도움 수락
         MessageDTO messageHelperDTO = new MessageDTO();
         messageHelperDTO.setTo(helperUserEntity.getUserPhone());
-        messageHelperDTO.setContent("도움 요청이 수락되었습니다.\n"+
-                "도움을 요청한 사용자의 연락처 :"+helpUserEntity.getUserPhone()
-                +"\n도움을 요청한 사용자의 이름 :"+helpUserEntity.getUserName()
+        messageHelperDTO.setContent("도움 요청이 수락되었습니다.\n" +
+                "도움을 요청한 사용자의 연락처 :" + helpUserEntity.getUserPhone()
+                + "\n도움을 요청한 사용자의 이름 :" + helpUserEntity.getUserName()
         );
 
         helpSmsService.sendSms(messageHelperDTO);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,3 +49,5 @@ spring.http.encoding.force=true
 
 
 
+
+


### PR DESCRIPTION
## 📌 관련 이슈
  closed #35


## ✨ 변경 내용
- 기존 코드에서 글 조회를 할 때 동일한 region을 갖는 user의 수만큼 동일한 글이 중복 출력되는 오류가 있어 수정함

- 도움을 요청하는 사람의 지역 정보(구)를 받아오고, 로그인 확인시 받아오는 사용자의 email을 통해 HelpRegion 테이블의 지역 정보를 받아옴 거기에 저장되어 있는 도움 주는 사람의 지역 정보가 일치하면 도움 요청 글이 조회되는 방식

- 글 조회, 리워드 획득 관련 동작 확인 완료 (로그인 확인)

- 도움 요청, 수락 관련 동작 확인 필요 (sms 기능 확인을 혼자 할 수 없어 아직 못했습니다..)

- 글 조회 url : http://localhost:8082/help/read?region_2depth_name={받아올 지역 정보}
     ex. http://localhost:8082/help/read?region_2depth_name=동작구

- 리워드 획득 url : http://localhost:8082/help/reward?rating={등록할 평점}
     ex. http://localhost:8082/help/reward?rating=5

- 리워드 획득의 경우, 별점 0~5점까지 있으며 포인트는 0점에서 시작해 10점씩 올라감 (별점 0점 : 0points, 1점 : 10points etc...)

- postman 사용할 때 로그인 후 받아온 access token을 authorization에 넣어주면 헤더에 자동으로 토큰 추가됨 (Bearer Token)

- 글 조회, 리워드 획득 모두 get 메서드 사용 (body 내용 입력 불필요)


## 📸 스크린샷(선택)
![리워드 획득](https://github.com/HyoZaSon/BackEnd/assets/127376237/97c066d3-6d12-4ba8-bb2d-2a2124e581bf)
![글 조회](https://github.com/HyoZaSon/BackEnd/assets/127376237/71f814bf-0d22-4dca-aad7-519afb891b36)
![리워드 적용 후](https://github.com/HyoZaSon/BackEnd/assets/127376237/6a7645f3-5beb-4291-909e-51d23c1172d2)
![리워드 적용 전](https://github.com/HyoZaSon/BackEnd/assets/127376237/8f8ac04b-fd7a-43ec-8954-cbc10f976636)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들

